### PR TITLE
#3 - 항상 github action으로 인해 discord bot이 떠있을 수 있도록 설정합니다.

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,34 @@
+name: Run Discord Bot
+
+on:
+  schedule:
+    - cron: "0 */3 * * *"  # 3시간마다 실행
+  workflow_dispatch:  # 수동 실행 가능
+
+concurrency:
+  group: discord-bot
+  cancel-in-progress: true  # 이전 실행이 있으면 강제 종료
+
+jobs:
+  run-bot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install discord.py apscheduler aiohttp aiosignal pytz schedule tzlocal
+
+      - name: Run script
+        env:
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          DISCORD_CHANNEL_ID: ${{ secrets.AUTHORIZATION_CHANNEL_ID }}
+        run: python presentation/Main.py

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.idea/
+.python-version


### PR DESCRIPTION
- 3시간마다 실행합니다.
- 만일 이전 run 정보가 살아있는 상태에서 job이 run 된다면 이전 job을 죽입니다.

#3 